### PR TITLE
added api to return flagged stories in descending order of number of flags

### DIFF
--- a/dao/story.dao.server.js
+++ b/dao/story.dao.server.js
@@ -67,6 +67,8 @@ const unflagStory = (story, userID) => {
     }
     return null;
 };
+const getSortedFlagged = (numberOfStories) =>
+    storyModel.find({ $where: "this.flagged_by_users.length > 0" }).sort({flagged_by_users: 'desc'}).limit(parseInt(numberOfStories));
 
 module.exports = {
     findAllStories,
@@ -85,5 +87,6 @@ module.exports = {
     likeStory,
     unlikeStory,
     flagStory,
-    unflagStory
+    unflagStory,
+    getSortedFlagged
 };

--- a/dao/story.dao.server.js
+++ b/dao/story.dao.server.js
@@ -67,8 +67,14 @@ const unflagStory = (story, userID) => {
     }
     return null;
 };
+// const getSortedFlagged = (numberOfStories) =>
+//     storyModel.find({ $where: "this.flagged_by_users.length > 0" }).sort({flagged_by_users: 'desc'}).limit(parseInt(numberOfStories));
 const getSortedFlagged = (numberOfStories) =>
-    storyModel.find({ $where: "this.flagged_by_users.length > 0" }).sort({flagged_by_users: 'desc'}).limit(parseInt(numberOfStories));
+    storyModel.aggregate([
+        {$unwind: "$flagged_by_users"},
+        {$group: {"_id": "$_id","story_id":  { "$first": "$story_id" }, answers: {$push:"$flagged_by_users"}, size: {$sum:1}}},
+        {$sort:{size:-1}}]).limit(parseInt(numberOfStories));
+
 
 module.exports = {
     findAllStories,

--- a/routes/story.route.server.js
+++ b/routes/story.route.server.js
@@ -384,16 +384,20 @@ module.exports = app => {
         }
     };
 
+    let getSortedByFlagged = (req, res) => storyDao.getSortedFlagged(req.params.numberOfStories).then(stories => res.json(stories));
+
+
     app.get('/stories', findAllStories);
     app.get('/stories/story/:storyID', findStoryByStoryID);
     app.get('/stories/place/:placeID',findStoryByPlaceID);
     app.get('/stories/title/:title',findStoryByTitle);
-    app.get('/stories/topStories/:numberOfStories', findTopStories)
-    app.get('/stories/unrated', findUnratedStories)
+    app.get('/stories/topStories/:numberOfStories', findTopStories);
+    app.get('/stories/unrated', findUnratedStories);
     app.get('/stories/description/:description',findStoryByDescription);
     app.get('/stories/sector/:sector', findStoryBySector);
     app.get('/stories/solution/:solution', findStoryBySolution);
     app.get('/stories/strategy/:strategy', findStoryByStrategy);
+    app.get('/stories/flagged/sorted/:numberOfStories', getSortedByFlagged);
     app.post('/stories/create', createStory);
     app.delete('/stories/delete/:storyId', deleteStory);
     app.put('/stories/update/:storyId', updateStory);

--- a/routes/story.route.server.js
+++ b/routes/story.route.server.js
@@ -384,7 +384,14 @@ module.exports = app => {
         }
     };
 
-    let getSortedByFlagged = (req, res) => storyDao.getSortedFlagged(req.params.numberOfStories).then(stories => res.json(stories));
+    let getSortedByFlagged = (req, res) => {
+        const numberOfStoriesToSend = parseInt(req.params.numberOfStories);
+        if (isNaN(numberOfStoriesToSend) || numberOfStoriesToSend <= 0) { //If non integer values provided for limit or page
+            console.log("Error");
+            return res.status(400).send({"Error": "Invalid Query Params"})
+        }
+        storyDao.getSortedFlagged(numberOfStoriesToSend).then(stories => res.json(stories));
+    };
 
 
     app.get('/stories', findAllStories);

--- a/tests/story.test.js
+++ b/tests/story.test.js
@@ -1004,67 +1004,26 @@ describe('End Points for Stories', () => {
         });
 
         it('/v1/stories/flagged/sorted/5 - return flagged stories in descending order with limit', (done) => {
-            request(app).get('/stories/flagged/sorted/5')
+            request(app).get('/v1/stories/flagged/sorted/5')
                 .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
+                .expect(200, done)
+                .expect('Content-Type', /json/);
         });
 
         it('/v1/stories/flagged/sorted/aaa - wrong parameters', (done) => {
-            request(app).get('/stories/flagged/sorted/aaa')
+            request(app).get('/v1/stories/flagged/sorted/aaa')
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
                 .expect(400, done);
         });
 
         it('/v1/stories/flagged/sorted/-1 - return flagged stories negative paramter', (done) => {
-            request(app).get('/stories/flagged/sorted/-1')
+            request(app).get('/v1/stories/flagged/sorted/-1')
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
                 .expect(400, done);
         });
-      
-        it('/v1/stories/all/solution - return all solutions', (done) => {
-            request(app).get('/stories/all/solution')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
-
-        it('/v1/stories/all/sector - return all sectors', (done) => {
-            request(app).get('/stories/all/sector')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
-
-        it('/v1/stories/all/strategy - return all strategies', (done) => {
-            request(app).get('/stories/all/strategy')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
-
-        it('/v1/stories/all/solution/:solution - return solutions containing string test', (done) => {
-            request(app).get('/stories/all/solution/test')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
-
-        it('/v1/stories/all/sector/:sector - return sectors containing string test', (done) => {
-            request(app).get('/stories/all/sector/test')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
-
-        it('/v1/stories/all/strategy/:strategy - return strategies containing string test', (done) => {
-            request(app).get('/stories/all/strategy/test')
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200, done);
-        });
+        
     });
 
     describe('DELETE/', () => {

--- a/tests/story.test.js
+++ b/tests/story.test.js
@@ -1010,6 +1010,20 @@ describe('End Points for Stories', () => {
                 .expect(200, done);
         })
 
+        it('/stories/flagged/sorted/aaa - wrong parametrs', (done) => {
+            request(app).get('/stories/flagged/sorted/aaa')
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect(400, done);
+        })
+
+        it('/stories/flagged/sorted/-1 - return flagged stories negative paramter', (done) => {
+            request(app).get('/stories/flagged/sorted/-1')
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect(400, done);
+        })
+
 
     });
 

--- a/tests/story.test.js
+++ b/tests/story.test.js
@@ -148,7 +148,8 @@ describe('End Points for Stories', () => {
                 date: '11/08/2012 04:23 AM'
             }
         ],
-        liked_by_users: []
+        liked_by_users: [],
+        flagged_by_users: [456]
     };
 
     const story4 = {
@@ -617,7 +618,7 @@ describe('End Points for Stories', () => {
 
         const resultStories = await storyDao.findStoryBySolution('Building Automation');
         expect(resultStories.length === 1)
-    })
+    });
 
     it('can find unrated stories - findUnratedStories API', async () => {
         await storyDao.createStory(story5);
@@ -626,7 +627,15 @@ describe('End Points for Stories', () => {
         const resultStories = await storyDao.findUnratedStories();
         stories = [story5];
         expect(resultStories.length === 1)
-    })
+    });
+
+    it('can return flagged stories in descending order', async () => {
+        await storyDao.createStory(story3);
+
+        const resultStories = await storyDao.getSortedFlagged(5);
+        expect(resultStories.length === 1);
+    });
+
     describe('POST/', () => {
         it('/stories/create - create a properly structured story', (done) => {
             request(app).post('/stories/create')
@@ -993,6 +1002,13 @@ describe('End Points for Stories', () => {
                 .expect('Content-Type', /json/)
                 .expect(400, done);
         });
+
+        it('/stories/flagged/sorted/5 - return flagged stories in descending order with limit', (done) => {
+            request(app).get('/stories/flagged/sorted/5')
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect(200, done);
+        })
 
 
     });


### PR DESCRIPTION
### Change type:
- New feature

###Description:
- Implements a new api

### Trello Card Link:
https://trello.com/c/XnWn5BDk/114-return-flagged-stories-in-sorted-order-5

### PR Checklist:
- [ ] Changes do not introduce new warnings or errors
- [ ] Tests were added or modified to cover changes
- [ ] All new and existing tests pass

### Steps to Verify This PR
- checkout code and access the api - localhost:3000/stories/flagged/sorted/5 - should only return upto 5 stories which have been flagged and in the descending order of the number of flags. 
