### PR TITLE
Modified deleting all indexes to deleting story index

### DIFF
--- a/db/elasticsearch.js
+++ b/db/elasticsearch.js
@@ -4,13 +4,13 @@ var esClient=null;
 
 const storyIndexInit=async ()=>{
     await esClient.indices.delete({
-                              index: '_all'
+                              index: 'storys'
                           }, function(err, res) {
 
         if (err) {
             console.error(err.message);
         } else {
-            console.log('Indexes have been deleted!');
+            console.log('Index storys has been deleted!');
         }
     });
     var stream = storyModel.synchronize(), count = 0;


### PR DESCRIPTION
Issue: When the server is run, it deletes all the indexs available on ES. This can cause us to any other data that we may store on ES in the future.

Fix: Modify the code to delete only the 'storys' index. 