### PR TITLE
Fixing minor error on findTopStories

### DIFF
--- a/dao/es.story.dao.server.js
+++ b/dao/es.story.dao.server.js
@@ -77,7 +77,7 @@ const findTopStories=(numberOfStories,successfulCallback,failCallback)=>{
     storyModel.search({match_all: {}}, {
         "size": numberOfStories,
         "sort" : [
-            { "date" : {"order" : "asc"}}]
+            { "date" : {"order" : "desc"}}]
     },function(err,res){
         if(err)failCallback(err);
         successfulCallback(res.hits.hits);


### PR DESCRIPTION
Issue: TopStories API is finding the oldest stories instead of the newest stories. 
Fix: Change the sorting of the stories from asc to desc